### PR TITLE
feat(scmp.py): attach jpeg back to zip file.

### DIFF
--- a/examples/scmpbot.py
+++ b/examples/scmpbot.py
@@ -26,6 +26,7 @@ import logging
 import os
 import zipfile
 from pathlib import Path
+import shutil
 
 import anyio
 import asks  # type: ignore
@@ -165,6 +166,23 @@ def parse_proofmode_zip_to_photo(zipfilepath):
             else:
                 continue
 
+def replace_photo_in_zip(zipfilepath, photofilepath):
+    fname, fext = os.path.splitext(zipfilepath)
+    fpath = fname + '-cai-cai-cai' + fext
+    shutil.copyfile(zipfilepath, fpath)
+    z = zipfile.ZipFile(fpath, "w")
+    with zipfile.ZipFile(zipfilepath) as myzip:
+        for fname in myzip.namelist():
+            # skip *.jpg
+            if not fname.endswith(".jpg"):
+                with myzip.open(fname, mode="r") as f:
+                    data = f.read()
+                    z.writestr(fname, data)
+    z.close()
+    z = zipfile.ZipFile(fpath, "a")
+    z.write(photofilepath)
+    z.close()
+    return fpath
 
 def resize_image(image_bytes, scale=0.3):
     '''Resize image bytes by the given scale.
@@ -291,6 +309,7 @@ async def ipfs(ctx: ChatContext) -> None:
                                              proofmode_json,
                                              metadata=None,
                                              right_owner=ctx.message.source.number)
+                Latest_photo = replace_photo_in_zip(attachment.stored_filename, Latest_photo)
             else:
                 print('Unknown type', attachment.content_type)
                 return


### PR DESCRIPTION
Instead of sending out JPEG files. We add JPEG files back to
the original zip file and send it out.
